### PR TITLE
Consider error property (hapi17)

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -22,6 +22,7 @@ class Errors extends Stream.Transform {
     _transform(data, enc, next) {
 
         internals.deepAddStringifyAble(data.data);
+        internals.deepAddStringifyAble(data.error);
 
         return next(null, data);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ const it = lab.it;
 
 describe('Errors', () => {
 
-    it('add stringifyable property to error objects', (done) => {
+    it('add stringifyable property to error objects located in the data property', (done) => {
 
         const stream = new GoodErrors.Errors({});
 
@@ -33,6 +33,26 @@ describe('Errors', () => {
         const err = new Error('foo');
         err.stack = 'Some\nstack';
         stream.end({ data: err });
+    });
+
+    it('add stringifyable property to error objects located in the error property', (done) => {
+
+        const stream = new GoodErrors.Errors({});
+
+        stream.on('readable', () => {
+
+            const result = stream.read();
+
+            if (!result) {
+                return done();
+            }
+
+            expect(result.error.stringifyable).to.equal({ name: 'Error', stack: 'Some\nstack', message: 'foo' });
+        });
+
+        const err = new Error('foo');
+        err.stack = 'Some\nstack';
+        stream.end({ error: err });
     });
 
     it('add stringifyable property to boom wrapped error objects', (done) => {


### PR DESCRIPTION
From the [Hapi 17 release notes](https://github.com/hapijs/hapi/issues/3658)

> - Changes to internal logging:
...
   -When event data is an error, event.error is provided instead of event.data.

As such `good-errors` should also consider the `error` property of an event to ensure it catches the new errors too.

Also related: https://github.com/hapijs/good/pull/585