### PR TITLE
Upgrade to @hapi namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Example usage as hapijs server options:
 
 ```javascript
 const options = {
-  reporters: {
-    consoleReporter: [
-      {
-        module: "@hapi/good-squeeze",
-        name: "Squeeze",
-        args: [{ log: "*", response: "*" }]
-      },
-      {
-        module: "@hapi/good-errors"
-      },
-      {
-        module: "@hapi/good-console"
-      },
-      "stdout"
-    ]
-  }
+    reporters: {
+        consoleReporter: [
+            {
+                module: '@hapi/good-squeeze',
+                name: 'Squeeze',
+                args: [{ log: '*', response: '*' }]
+            },
+            {
+                module: '@hapi/good-errors'
+            },
+            {
+                module: '@hapi/good-console'
+            },
+            'stdout'
+        ]
+    }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const options = {
                 args: [{ log: '*', response: '*' }]
             },
             {
-                module: '@hapi/good-errors'
+                module: 'good-errors'
             },
             {
                 module: '@hapi/good-console'

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # good-errors
+
 Utility stream to transform errors to object literals.
 
 [![Build Status](https://travis-ci.org/benleen/good-errors.svg?branch=master&style=flat)](https://travis-ci.org/benleen/good-errors)
 
 Example usage as hapijs server options:
-```
+
+```javascript
 const options = {
-    reporters: {
-        consoleReporter: [
-        {
-            module: 'good-squeeze',
-            name: 'Squeeze',
-            args: [{ log: '*', response: '*' }]
-        },
-        {
-            module: 'good-errors'
-        },
-        {
-            module: 'good-console'
-        },
-        'stdout',
-        ],
-    },
-}
+  reporters: {
+    consoleReporter: [
+      {
+        module: "@hapi/good-squeeze",
+        name: "Squeeze",
+        args: [{ log: "*", response: "*" }]
+      },
+      {
+        module: "@hapi/good-errors"
+      },
+      {
+        module: "@hapi/good-console"
+      },
+      "stdout"
+    ]
+  }
+};
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "stream"
   ],
   "scripts": {
-    "test": "lab -m 5000 -t 100 -L -a code"
+    "test": "lab -m 5000 -t 100 -L -a @hapi/code"
   },
   "repository": {
     "type": "git",
@@ -23,17 +23,17 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "hoek": "^6.1.2"
+    "@hapi/hoek": "^8.0.2"
   },
   "devDependencies": {
-    "boom": "^7.2.0",
-    "code": "^5.2.0",
-    "good": "^8.1.0",
-    "good-squeeze": "^5.1.0",
-    "hapi": "^18.1.0",
-    "lab": "^18.0.1"
+    "@hapi/boom": "^7.4.2",
+    "@hapi/code": "^5.3.1",
+    "@hapi/good": "^8.2.0",
+    "@hapi/good-squeeze": "^5.2.0",
+    "@hapi/hapi": "^18.3.1",
+    "@hapi/lab": "^19.1.0"
   },
   "peerDependencies": {
-    "good": "^8.1.0"
+    "@hapi/good": "^8.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,18 +4,17 @@
 
 const GoodErrors = require('..');
 
-const Code = require('code');
-const Lab = require('lab');
-const Boom = require('boom');
-const Hapi = require('hapi');
-const Good = require('good');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const Boom = require('@hapi/boom');
+const Hapi = require('@hapi/hapi');
+const Good = require('@hapi/good');
 const Stream = require('stream');
 
-const lab = exports.lab = Lab.script();
+const lab = (exports.lab = Lab.script());
 const expect = Code.expect;
 const describe = lab.describe;
 const it = lab.it;
-
 
 const internals = {
     buildSampleError: function () {
@@ -24,7 +23,11 @@ const internals = {
         err.stack = 'Some\nstack';
         return err;
     },
-    sampleErrorAsStringifyable: { name: 'Error', stack: 'Some\nstack', message: 'foo' },
+    sampleErrorAsStringifyable: {
+        name: 'Error',
+        stack: 'Some\nstack',
+        message: 'foo'
+    },
     goodErrorStreamInput: function (streamInput) {
 
         return new Promise((resolve, reject) => {
@@ -45,14 +48,18 @@ describe('Errors', () => {
 
         const input = { data: internals.buildSampleError() };
         const result = await internals.goodErrorStreamInput(input);
-        expect(result.data.stringifyable).to.equal(internals.sampleErrorAsStringifyable);
+        expect(result.data.stringifyable).to.equal(
+            internals.sampleErrorAsStringifyable
+        );
     });
 
     it('add stringifyable property to error objects on the error property', async () => {
 
         const input = { error: internals.buildSampleError() };
         const result = await internals.goodErrorStreamInput(input);
-        expect(result.error.stringifyable).to.equal(internals.sampleErrorAsStringifyable);
+        expect(result.error.stringifyable).to.equal(
+            internals.sampleErrorAsStringifyable
+        );
     });
 
     it('add stringifyable property to boom wrapped error objects', async () => {
@@ -60,17 +67,27 @@ describe('Errors', () => {
         const input = { data: Boom.boomify(internals.buildSampleError()) };
         const result = await internals.goodErrorStreamInput(input);
         expect(result.data.isBoom).to.equal(true);
-        expect(result.data.stringifyable).to.equal(internals.sampleErrorAsStringifyable);
+        expect(result.data.stringifyable).to.equal(
+            internals.sampleErrorAsStringifyable
+        );
     });
 
     it('add stringifyable property to errors nested in a passed error object (boom error)', async () => {
 
-        const input = { data:  Boom.internal('message', { err: internals.buildSampleError(), some: 'other', important: 'props' }) };
+        const input = {
+            data: Boom.internal('message', {
+                err: internals.buildSampleError(),
+                some: 'other',
+                important: 'props'
+            })
+        };
         const result = await internals.goodErrorStreamInput(input);
         expect(result.data.isBoom).to.equal(true);
         expect(result.data.data.some).to.equal('other');
         expect(result.data.data.important).to.equal('props');
-        expect(result.data.data.err.stringifyable).to.equal(internals.sampleErrorAsStringifyable);
+        expect(result.data.data.err.stringifyable).to.equal(
+            internals.sampleErrorAsStringifyable
+        );
     });
 
     it('leaves non error data untouched', async () => {
@@ -82,11 +99,15 @@ describe('Errors', () => {
 
     it('add stringifyable property to Error objects deeper in the passed object', async () => {
 
-        const input = { data: { a: 1, b: { c: 'x', d: internals.buildSampleError() } } };
+        const input = {
+            data: { a: 1, b: { c: 'x', d: internals.buildSampleError() } }
+        };
         const result = await internals.goodErrorStreamInput(input);
         expect(result.data.a).to.equal(1);
         expect(result.data.b.c).to.equal('x');
-        expect(result.data.b.d.stringifyable).to.equal(internals.sampleErrorAsStringifyable);
+        expect(result.data.b.d.stringifyable).to.equal(
+            internals.sampleErrorAsStringifyable
+        );
     });
 
     it('leaves non objects untouched', async () => {
@@ -124,18 +145,24 @@ describe('Errors', () => {
 
     it('accepts objects with circular dependencies', async () => {
 
-        const input = { data: { a: 1, b: { c: 'x', d: internals.buildSampleError() } } };
+        const input = {
+            data: { a: 1, b: { c: 'x', d: internals.buildSampleError() } }
+        };
         input.data.b.circ = input.data;
         const result = await internals.goodErrorStreamInput(input);
         expect(result.data).to.exist();
-        expect(result.data.b.d.stringifyable).to.equal({ name: 'Error', stack: 'Some\nstack', message: 'foo' });
+        expect(result.data.b.d.stringifyable).to.equal({
+            name: 'Error',
+            stack: 'Some\nstack',
+            message: 'foo'
+        });
     });
 
     it('ensures basic compatibility with hapi, good & good-squeeze for errors', async () => {
 
         const server = new Hapi.server();
 
-        class ValidationWriteStream extends Stream.Writable{
+        class ValidationWriteStream extends Stream.Writable {
             constructor(options) {
 
                 options = Object.assign({}, options, {
@@ -148,23 +175,35 @@ describe('Errors', () => {
                 expect(data.error.stringifyable).to.exist();
                 expect(data.error.stringifyable.message).to.equal('Boom!');
                 expect(data.error.stringifyable.name).to.equal('Error');
-                expect(data.error.stringifyable.stack).to.startWith('Error: Boom!\n    at handler');
+                expect(data.error.stringifyable.stack).to.startWith(
+                    'Error: Boom!\n    at handler'
+                );
 
                 return next(null, data);
-            };
+            }
         }
 
         const options = {
             reporters: {
-                reporter: [{ module: 'good-squeeze', name: 'Squeeze', args: [{ error: '*' }] },
+                reporter: [
+                    {
+                        module: '@hapi/good-squeeze',
+                        name: 'Squeeze',
+                        args: [{ error: '*' }]
+                    },
                     { module: GoodErrors },
-                    { module: ValidationWriteStream }]
+                    { module: ValidationWriteStream }
+                ]
             }
         };
 
         await server.register({ plugin: Good, options });
         await server.start();
-        await server.route({ method: 'GET', path: '/', handler: () => Error('Boom!') });
+        await server.route({
+            method: 'GET',
+            path: '/',
+            handler: () => Error('Boom!')
+        });
         await server.inject('/');
 
     });


### PR DESCRIPTION
Hi @benleen

Fix for issue #11

I have upgraded the packages to use the @hapi namespace, just to get rid of package warnings.

There is a few formatting fixes that VS code did automatically, I manually fixed a few outside of VS code so your tests continue to pass.
