### PR TITLE
Upgrade dependencies, remove hoek as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,18 +22,15 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "dependencies": {
-    "@hapi/hoek": "^8.0.2"
-  },
   "devDependencies": {
-    "@hapi/boom": "^7.4.2",
-    "@hapi/code": "^5.3.1",
-    "@hapi/good": "^8.2.0",
-    "@hapi/good-squeeze": "^5.2.0",
-    "@hapi/hapi": "^18.3.1",
-    "@hapi/lab": "^19.1.0"
+    "@hapi/boom": "^9.1.4",
+    "@hapi/code": "^8.0.7",
+    "@hapi/good": "^9.0.1",
+    "@hapi/good-squeeze": "^6.0.0",
+    "@hapi/hapi": "^20.2.2",
+    "@hapi/lab": "^24.6.0"
   },
   "peerDependencies": {
-    "@hapi/good": "^8.2.0"
+    "@hapi/good": "^9.0.1"
   }
 }


### PR DESCRIPTION
Initially was doing this because of a Prototype Pollution vuln, https://security.snyk.io/vuln/SNYK-JS-HAPIHOEK-548452 but I missed that @hapi/hoek 8.5.1 exists, is major-version-compatible, and resolves it.
Still, don't see any reason why this package necessarily depends on `@hapi/hoek` explicitly, since it uses fairly basic stream functionality, and doesn't explicitly import from hoek.

Figured I would update other dependencies at the same time. It does seem to be compatible with @hapi/good v9 (from my usage), though I'm unsure if the peer-dependency upgrade counts as a breaking change.